### PR TITLE
[Trim] Add trim path support

### DIFF
--- a/internal/command/handle.go
+++ b/internal/command/handle.go
@@ -31,36 +31,42 @@ func Run(args []string) error {
 	// trim
 	if command == "trim" {
 		if len(args) < 3 {
-			pterm.Info.Println("Usage: trim [duration] Delete files older than this in seconds or ms|s|m|h|d|w|M|y Ex: 10d or 10s")
+			pterm.Info.Println("Usage: trim [path] [duration] Delete files older than this in seconds or ms|s|m|h|d|w|M|y Ex: 10d or 10s")
 			os.Exit(0)
 		}
 
-		return rclone.Trim(args[2])
+		destinationPath := args[2]
+		duration := args[3]
+		if destinationPath == "." {
+			destinationPath = ""
+		}
+
+		return rclone.Trim(destinationPath, duration)
 	}
 
 	// exist
 	// checks for if backups or files exist within this time in location
 	if command == "exist" {
 		if len(args) < 3 {
-			pterm.Info.Println("Usage: exist [duration] [destination-path] Check for existence of files newer than this in seconds or alert. ms|s|m|h|d|w|M|y Ex: 10d or 10s")
+			pterm.Info.Println("Usage: exist [destination-path] [duration] Check for existence of files newer than this in seconds or alert. ms|s|m|h|d|w|M|y Ex: 10d or 10s")
 			os.Exit(0)
 		}
 
-		duration := args[2]
-		destinationPath := ""
-		if len(args) > 3 {
-			destinationPath = args[3]
+		duration := args[3]
+		destinationPath := args[2]
+		if destinationPath == "." {
+			destinationPath = ""
 		}
 
-		return rclone.Exist(duration, destinationPath)
+		return rclone.Exist(destinationPath, duration)
 	}
 
 	pterm.NewRGB(15, 199, 209).Println("")
 	pterm.NewRGB(15, 199, 209).Println("[rclone-multi] A simple wrapper for rclone for multi-remote backup operations")
 	pterm.NewRGB(15, 199, 209).Println("")
 	pterm.NewRGB(15, 199, 209).Println("> upload [source-file] [destination-path]")
-	pterm.NewRGB(15, 199, 209).Println("> trim [duration] Delete files older than this in seconds or ms|s|m|h|d|w|M|y Ex: 10d or 10s")
-	pterm.NewRGB(15, 199, 209).Println("> exist [duration] [destination-path] Check for existence of files newer than this in seconds or alert. ms|s|m|h|d|w|M|y Ex: 10d or 10s")
+	pterm.NewRGB(15, 199, 209).Println("> trim [destination-path (. for current dir)] [duration] Delete files older than this in seconds or ms|s|m|h|d|w|M|y Ex: 10d or 10s")
+	pterm.NewRGB(15, 199, 209).Println("> exist [destination-path (. for current dir)] [duration] Check for existence of files newer than this in seconds or alert. ms|s|m|h|d|w|M|y Ex: 10d or 10s")
 	pterm.NewRGB(15, 199, 209).Println("")
 
 	return nil

--- a/internal/rclone/exist.go
+++ b/internal/rclone/exist.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Exist will check for files that exist within a timeframe or alert
-func Exist(duration string, destPath string) error {
+func Exist(destPath string, duration string) error {
 	pterm.Info.Printf("Checking for existence of files duration [%v] via remotes to path [%v]\n", duration, destPath)
 
 	for _, remote := range getRemotes() {
@@ -16,6 +16,7 @@ func Exist(duration string, destPath string) error {
 		pterm.Info.Println(cmd)
 
 		output, _ := execCmd("bash", "-c", cmd)
+		pterm.Info.Println(output)
 
 		pterm.Info.Printf("Remote [%v]\n", remote)
 

--- a/internal/rclone/exist.go
+++ b/internal/rclone/exist.go
@@ -16,10 +16,10 @@ func Exist(destPath string, duration string) error {
 		pterm.Info.Println(cmd)
 
 		output, _ := execCmd("bash", "-c", cmd)
+		pterm.Info.Printf("Remote [%v] [%v]\n", remote, cmd)
+
 		pterm.Info.Println(output)
-
-		pterm.Info.Printf("Remote [%v]\n", remote)
-
+		
 		// no files
 		if len(strings.Split(output, "\n")) == 1 {
 			notify.Alert(

--- a/internal/rclone/trim.go
+++ b/internal/rclone/trim.go
@@ -6,6 +6,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/pterm/pterm"
 	"log"
+	"path"
 	"strconv"
 	"strings"
 )
@@ -20,7 +21,8 @@ func Trim(destPath string, time string) error {
 		cmd := fmt.Sprintf("rclone lsl %v:%v --min-age=%v", remote, destPath, time)
 		output, _ := execCmd("bash", "-c", cmd)
 
-		pterm.Info.Printf("Remote [%v]\n", remote)
+		pterm.Info.Printf("Remote directory listing [%v] [%v]\n", remote, cmd)
+		pterm.Info.Printf("%v\n", output)
 
 		for _, line := range strings.Split(output, "\n") {
 			line = strings.TrimSpace(line)
@@ -37,7 +39,9 @@ func Trim(destPath string, time string) error {
 
 				pterm.Info.Printf("Deleting [%v] via [%v]\n", fileName, remote)
 
-				del := fmt.Sprintf("rclone deletefile %v:%v", remote, fileName)
+				destFile := path.Join(destPath, fileName)
+
+				del := fmt.Sprintf("rclone deletefile %v:%v", remote, destFile)
 				pterm.Info.Println(del)
 				_, err = execCmd("bash", "-c", del)
 				if err != nil {
@@ -51,7 +55,7 @@ func Trim(destPath string, time string) error {
 					return err
 				}
 
-				pterm.Success.Printf("[DONE] Deleting [%v] from [%v]\n", fileName, remote)
+				pterm.Success.Printf("[DONE] Deleting [%v] from [%v]\n", destFile, remote)
 
 				// send to notifiers
 				notify.Info(

--- a/internal/rclone/trim.go
+++ b/internal/rclone/trim.go
@@ -11,12 +11,13 @@ import (
 )
 
 // Trim will trim files older than specified time
+// in the specified directory
 // example 10d will trim files older than 10 days
-func Trim(time string) error {
+func Trim(destPath string, time string) error {
 	pterm.Info.Printf("Deleting files older than [%v]\n", time)
 
 	for _, remote := range getRemotes() {
-		cmd := fmt.Sprintf("rclone lsl %v: --min-age=%v", remote, time)
+		cmd := fmt.Sprintf("rclone lsl %v:%v --min-age=%v", remote, destPath, time)
 		output, _ := execCmd("bash", "-c", cmd)
 
 		pterm.Info.Printf("Remote [%v]\n", remote)


### PR DESCRIPTION
Adds path support to trim, whereas it would crawl the entire remote regardless of path and trim based on duration criteria. this poses a problem when you want to do path-specific trimming

Example of flows supporting path along with trim now included.

**go run main.go upload LICENSE newpath**

```
 INFO  Uploading file [LICENSE] via remotes to path [newpath]
 INFO  -- Remote [dropbox] Uploading [LICENSE] to [dropbox:newpath]
 SUCCESS  -- Remote [dropbox] Uploaded [LICENSE] to [dropbox:newpath]
```

**go run main.go exist newpath 10000000s**

```
 INFO  Checking for existence of files duration [10000000s] via remotes to path [newpath]
 INFO  rclone lsl dropbox:newpath --max-age=10000000s
 INFO  Remote [dropbox] [rclone lsl dropbox:newpath --max-age=10000000s]
 INFO      35129 2022-07-20 01:39:09.000000000 LICENSE
```

**go run main.go trim newpath 7d**

```
 INFO  Deleting files older than [7d]
 INFO  Remote directory listing [dropbox] [rclone lsl dropbox:newpath --min-age=7d]
 INFO      35129 2022-07-20 01:39:09.000000000 LICENSE
 INFO  Deleting [LICENSE] via [dropbox]
 INFO  rclone deletefile dropbox:newpath/LICENSE
 SUCCESS  [DONE] Deleting [newpath/LICENSE] from [dropbox]
```
